### PR TITLE
Fix issuer directory URL to use IANA registered well-known endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import {
 	IssuerConfig,
+	PRIVATE_TOKEN_ISSUER_DIRECTORY,
 	PrivateToken,
 	TOKEN_TYPES,
 	Token,
@@ -43,7 +44,7 @@ async function fetchBasicIssuerKeys(env: Bindings, issuerName: string) {
 			'content-type': 'application/json',
 		},
 	};
-	const configURL = `${issuerURL}/.well-known/token-issuer-directory`;
+	const configURL = `${issuerURL}${PRIVATE_TOKEN_ISSUER_DIRECTORY}`;
 	const configResponse = await generateFetchIssuerEndpoint(env)(configURL, init);
 	const config: IssuerConfig = await configResponse.json();
 


### PR DESCRIPTION
The issuer config was hardcoded to
`/.well-known/private-token-issuer-directory`. This is part of an old version of the Privacy Pass protocol draft, and not registered with IANA.

This commit updates the code to use endpoint provided by @cloudflare/privacypass-ts, which is compliant with the latest draft.

Closes #2