### PR TITLE
Fix ISSUER_NAME to ISSUER_URL to remove protocol ambiguity

### DIFF
--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,7 +1,7 @@
 export interface Bindings {
 	// variables and secrets
 	ENVIRONMENT: string;
-	ISSUER_NAME: string;
+	ISSUER_URL: string;
 	ORIGIN_NAME: string;
 
 	// Service Bindings

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,5 +16,5 @@ route = { pattern = "pp-origin.example.test", custom_domain=true }
 # ]
 
 [env.production.vars]
-ISSUER_NAME = "pp-issuer-public.research.cloudflare.com" # Use Cloudflare Research Public Issuer. This is only meant for experiments, AND SHOULD NOT BE USED ON A PRODUCTION SERVICE
+ISSUER_URL = "https://pp-issuer-public.research.cloudflare.com" # Use Cloudflare Research Public Issuer. This is only meant for experiments, AND SHOULD NOT BE USED ON A PRODUCTION SERVICE
 ORIGIN_NAME = "pp-origin.example.test"


### PR DESCRIPTION
Protocol to query an issuer cannot be solely retrieved from the issuer name. This is problematic when deployming a local issuer which should use http: instead of https:
This commit changes `ISSUER_NAME` to `ISSUER_URL` to address this.