### PR TITLE
Add environment variable support for all defaults in build script 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
 		"build": "tsc && node scripts/cli.js build",
 		"deploy:production": "wrangler publish --no-bundle --env production",
 		"dev": "wrangler dev --env production",
-		"format": "prettier --write  '*.{json,js}' 'src/**/*.{js,ts}'",
-		"lint": "eslint src && prettier --check '*.{json,js}' 'src/**/*.{js,ts}'"
+		"format": "prettier --write  '*.{json,js}' 'scripts/*.{js,ts}' 'src/**/*.{js,ts}'",
+		"lint": "eslint src && prettier --check '*.{json,js}' 'scripts/*.{js,ts}' 'src/**/*.{js,ts}'"
 	},
 	"eslintConfig": {
 		"parserOptions": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,51 +1,49 @@
-import fs from 'fs'
+import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url'
-import { build } from 'esbuild'
-import git from 'git-rev-sync'
-import Sentry from '@sentry/cli'
+import { fileURLToPath } from 'url';
+import { build } from 'esbuild';
+import git from 'git-rev-sync';
+import Sentry from '@sentry/cli';
 
-import 'dotenv/config.js'
+import 'dotenv/config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const pkg = JSON.parse(
-  fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
-)
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
 
-export async function buildCmd (opts) {
-  let version = git.tag()
-  if (git.hasUnstagedChanges() || git.isTagDirty()) {
-    version += '.next'
-  }
-  const release = `privacy-pass-origin@${version}-${opts.env}+${git.short(__dirname)}`
-  console.log(`Building ${release}`)
+export async function buildCmd(opts) {
+	let version = git.tag();
+	if (git.hasUnstagedChanges() || git.isTagDirty()) {
+		version += '.next';
+	}
+	const release = `privacy-pass-origin@${version}-${opts.env}+${git.short(__dirname)}`;
+	console.log(`Building ${release}`);
 
-  await build({
-    bundle: true,
-    sourcemap: true,
-    format: 'esm',
-    target: 'esnext',
-    external: ['__STATIC_CONTENT_MANIFEST'],
-    legalComments: 'external',
-    conditions: ['worker', 'browser'],
-    entryPoints: [path.join(__dirname, '..', 'src', 'index.ts')],
-    outfile: path.join(__dirname, '..', 'dist', 'worker.mjs'),
-    outExtension: { '.js': '.mjs' },
-    minify: false,
-    // handy variables for Sentry reporting
-    define: {
-      RELEASE: JSON.stringify(release),
-      VERSION: JSON.stringify(version),
-      COMMITHASH: JSON.stringify(git.long(__dirname)),
-      BRANCH: JSON.stringify(git.branch(__dirname)),
-    },
-  })
+	await build({
+		bundle: true,
+		sourcemap: true,
+		format: 'esm',
+		target: 'esnext',
+		external: ['__STATIC_CONTENT_MANIFEST'],
+		legalComments: 'external',
+		conditions: ['worker', 'browser'],
+		entryPoints: [path.join(__dirname, '..', 'src', 'index.ts')],
+		outfile: path.join(__dirname, '..', 'dist', 'worker.mjs'),
+		outExtension: { '.js': '.mjs' },
+		minify: false,
+		// handy variables for Sentry reporting
+		define: {
+			RELEASE: JSON.stringify(release),
+			VERSION: JSON.stringify(version),
+			COMMITHASH: JSON.stringify(git.long(__dirname)),
+			BRANCH: JSON.stringify(git.branch(__dirname)),
+		},
+	});
 
-  // Sentry release and sourcemap upload
-  if (process.env.SENTRY_API_TOKEN) {
-    let headers = {};
+	// Sentry release and sourcemap upload
+	if (process.env.SENTRY_API_TOKEN) {
+		let headers = {};
 		if (process.env.SENTRY_ACCESS_CLIENT_ID) {
 			headers['Cf-Access-Client-ID'] = process.env.SENTRY_ACCESS_CLIENT_ID;
 		}
@@ -61,19 +59,19 @@ export async function buildCmd (opts) {
 			headers,
 		});
 
-    // these are the API calls if the JS API was to support custom headers
-    await cli.releases.new(release)
-    await cli.releases.setCommits(release, {
-      auto: true,
-      ignoreEmpty: true,
-    })
-    await cli.releases.uploadSourceMaps(release, {
-      include: ['./dist'],
-      ext: ['map', 'mjs']
-    })
-    await cli.releases.finalize(release)
-    await cli.releases.newDeploy(release, {
-      env: opts.env
-    })
-  }
+		// these are the API calls if the JS API was to support custom headers
+		await cli.releases.new(release);
+		await cli.releases.setCommits(release, {
+			auto: true,
+			ignoreEmpty: true,
+		});
+		await cli.releases.uploadSourceMaps(release, {
+			include: ['./dist'],
+			ext: ['map', 'mjs'],
+		});
+		await cli.releases.finalize(release);
+		await cli.releases.newDeploy(release, {
+			env: opts.env,
+		});
+	}
 }

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -1,22 +1,22 @@
 #!/usr/bin/env node
-import path from 'path'
-import dotenv from 'dotenv'
-import { fileURLToPath } from 'url'
-import sade from 'sade'
+import path from 'path';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import sade from 'sade';
 
-import { buildCmd } from './build.js'
+import { buildCmd } from './build.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 dotenv.config({
-  path: path.join(__dirname, '..', '.env')
-})
+	path: path.join(__dirname, '..', '.env'),
+});
 
-const prog = sade('privacy-pass-cli')
+const prog = sade('privacy-pass-cli');
 
 prog
-  .command('build')
-  .describe('Build the worker.')
-  .option('--env', 'Environment', process.env.ENVIRONMENT ?? 'dev')
-  .action(buildCmd)
+	.command('build')
+	.describe('Build the worker.')
+	.option('--env', 'Environment', process.env.ENVIRONMENT ?? 'dev')
+	.action(buildCmd);
 
-prog.parse(process.argv)
+prog.parse(process.argv);


### PR DESCRIPTION
The build script assumed some default, specifically for Sentry integration. This commit keeps the default, but allow environment variables to override them.

This change also adds lint and format for build scripts